### PR TITLE
feat(docker-compose): change the port from 80 to 8080 for production

### DIFF
--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - firefly_iii_upload_prod:/var/www/firefly-iii/storage/upload
     env_file: .firefly-env
     ports:
-      - 8080:80
+      - 8080:8080
     depends_on:
       - fireflyiiidb-prod
     restart: unless-stopped


### PR DESCRIPTION
### What does this PR do?

This PR changes the port in the docker-compose.yml file on the container side as Firefly-iii now listens to port 8080.

### Background info?

Refer to the recent release notes of Firefly-iii.

### How was this tested?

I have tested the changes locally with Firefly-iii version 5.3.3

### Issue this PR is related to

This PR is related to issue #7 

close #7