### PR TITLE
feat(docker-compose): support 5.4.x releases

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -4,8 +4,7 @@ services:
   fireflyiii-dev:
     image: jc5x/firefly-iii:develop
     volumes:
-      - firefly_iii_export_dev:/var/www/firefly-iii/storage/export
-      - firefly_iii_upload_dev:/var/www/firefly-iii/storage/upload
+      - firefly_iii_upload_dev:/var/www/html/storage/upload
     env_file: .firefly-env
     ports:
       - 8081:8080
@@ -35,6 +34,5 @@ services:
     restart: unless-stopped # restarts container unless we explicitly stop it
 
 volumes:
-   firefly_iii_export_dev:
    firefly_iii_upload_dev:
    firefly_iii_db_dev:

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -4,11 +4,10 @@ services:
   fireflyiii-prod:
     image: jc5x/firefly-iii:latest
     volumes:
-      - firefly_iii_export_prod:/var/www/firefly-iii/storage/export
-      - firefly_iii_upload_prod:/var/www/firefly-iii/storage/upload
+      - firefly_iii_upload_prod:/var/www/html/storage/upload
     env_file: .firefly-env
     ports:
-      - 8080:80
+      - 8080:8080
     depends_on:
       - fireflyiiidb-prod
     restart: unless-stopped
@@ -21,6 +20,5 @@ services:
     restart: unless-stopped
 
 volumes:
-    firefly_iii_export_prod:
     firefly_iii_upload_prod:
     firefly_iii_db_prod:


### PR DESCRIPTION
### What does this PR do?

This PR modifies the `docker-compose.yml` files for dev and prod to support the latest 5.4.x releases.

### Background info

The following steps are needed to properly have the environment accept these changes:

Make sure the dev and prod services are stopped.

- docker ps -a (to identify the firefly containers)
- docker rm <container-id> (for removing the container we want to delete)
- docker volume ls (to find the volumes we want to remove, ex development_firefly_iii_export_dev)
- docker volume rm development_firefly_iii_export_dev
- docker volume rm production_firefly_iii_export_prod

Run the following in each environment folder:
- docker-compose pull
- docker-compose up

Firefly-iii should now be running properly.

### How was this tested?

I tested this locally with Firefly-iii with 5.4.6

### Which issue(s) is the PR related to?

This PR is related to #9 
close #9 