### PR TITLE
fix(watchtower): freeze watchtower version and update watchtower's notification documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,9 +94,12 @@ MAILGUN_ENDPOINT=api.mailgun.net # this is fine if you are in the U.S.
 
 #### .watchtower-env
 
+Below is an example of how I have configured Watchtower to send notifications with Rocket Chat. Please refer to Watchtower's
+documentation [here](https://containrrr.dev/watchtower/notifications/) to see how to configure notifications of your choice.
+
 ```
-WATCHTOWER_NOTIFICATIONS=slack
-WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL=<your-slack-hook-here> # btw, I am using rocket.chat :)
+WATCHTOWER_NOTIFICATIONS=shoutrrr
+WATCHTOWER_NOTIFICATION_URL=rocketchat://myserver.example.com/token/channel
 ```
 
 4.) Once you have the environment settings set for local `development` make the necessary changes for local `production`.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
   
   watchtower:
-    image: containrrr/watchtower
+    image: containrrr/watchtower:amd64-1.1.6
     volumes:
         - /var/run/docker.sock:/var/run/docker.sock
     # check for new images every Monday at 9:00 UTC and only watch watchtower,


### PR DESCRIPTION
### What does this PR do?

This PR freezes the Watchtower version used to 1.1.6. 

### Background info

The links below were referenced to implement the correct configuration.

- https://github.com/containrrr/watchtower/issues/776
- https://containrrr.dev/watchtower/notifications/
- https://containrrr.dev/shoutrrr/services/rocketchat/

### How was this tested?

The changes were tested locally after starting the local dev environment with the modifications made to `.watchtower-env`.

### Which issue(s) is the PR related to?

This PR is related to issue #11 

close #11