### PR TITLE
feat(docker-compose): replace the dockerhub repository for firefly-iii with the new one

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   fireflyiii-dev:
-    image: jc5x/firefly-iii:develop
+    image: fireflyiii/core:develop
     volumes:
       - firefly_iii_upload_dev:/var/www/html/storage/upload
     env_file: .firefly-env

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   fireflyiii-prod:
-    image: jc5x/firefly-iii:latest
+    image: fireflyiii/core:latest
     volumes:
       - firefly_iii_upload_prod:/var/www/html/storage/upload
     env_file: .firefly-env


### PR DESCRIPTION
### What does this PR do?

This PR modifies the `docker-compose.yml` files to now use the new DockerHub repositories for Firefly-iii  https://hub.docker.com/r/fireflyiii/core.

### Background info

N/A

### How was this tested?

I tested this locally with Firefly-iii with 5.5.13

### Which issue(s) is the PR related to?

This PR is related to #15 
close #15